### PR TITLE
Allow offset when downloading

### DIFF
--- a/googleapiclient/http.py
+++ b/googleapiclient/http.py
@@ -667,7 +667,7 @@ class MediaIoBaseDownload(object):
   """
 
     @util.positional(3)
-    def __init__(self, fd, request, chunksize=DEFAULT_CHUNK_SIZE):
+    def __init__(self, fd, request, chunksize=DEFAULT_CHUNK_SIZE, start=0):
         """Constructor.
 
     Args:
@@ -681,7 +681,7 @@ class MediaIoBaseDownload(object):
         self._request = request
         self._uri = request.uri
         self._chunksize = chunksize
-        self._progress = 0
+        self._progress = start
         self._total_size = None
         self._done = False
 


### PR DESCRIPTION
- Add start param to MediaIoBaseDownload.__init__ to allow partial download, for streaming

INSPIRED BY:  https://stackoverflow.com/questions/59815890/chunked-partial-download-using-google-drive-python-api
